### PR TITLE
Fix login redirect

### DIFF
--- a/pluxee/base_pluxee_client.py
+++ b/pluxee/base_pluxee_client.py
@@ -96,6 +96,8 @@ class _PluxeeClient:
         self._password = password or os.environ.get("PLUXEE_PASSWORD")
         self._language = language
         self._base_url_localized = f"https://{_PluxeeClient.DOMAIN}/{self._language}"
+        self._base_url_login = f"{self._base_url_localized}/user/login"
+        self._base_url_balance = f"{self._base_url_localized}"
         self._base_url_transactions = f"{self._base_url_localized}/" + ('mijn-sodexo-card-saldo' if self._language == 'nl' else 'mon-solde-sodexo-card')
         self._session = session
 
@@ -164,7 +166,7 @@ class _PluxeeClient:
 
     def gen_login_post_args(self):
         return {
-            "url": self._base_url_localized + "/frontpage",
+            "url": self._base_url_login,
             "params": {
                 "destination": f"/{self._language}/frontpage",
             },

--- a/pluxee/pluxee_async_client.py
+++ b/pluxee/pluxee_async_client.py
@@ -44,7 +44,7 @@ class PluxeeAsyncClient(_PluxeeClient):
     async def _make_request(self, url: str, params: Dict[str, Union[str, int]], session) -> _ResponseWrapper:
         async with session.get(url, params=params) as response:
             content = await response.text()
-            if f"href=\"/{self._language}/user/logout\"" in content:
+            if 'logout' in content.lower():
                 return _ResponseWrapper(content, response.status)
 
         # We got disconnected, the cookies expired
@@ -78,7 +78,7 @@ class PluxeeAsyncClient(_PluxeeClient):
         session: aiohttp.ClientSession
 
         try:
-            response = await self._make_request(self._base_url_localized, {"check_logged_in": "1"}, session)
+            response = await self._make_request(self._base_url_balance, {"check_logged_in": "1"}, session)
             return self._parse_balance_from_response(response)
         finally:
             if not self._session:

--- a/pluxee/pluxee_client.py
+++ b/pluxee/pluxee_client.py
@@ -83,7 +83,7 @@ class PluxeeClient(_PluxeeClient):
         with self.TemporaryPEMFile(self._base_url_localized) as ssl_context:
             session: requests.Session = self._session or requests.Session()
             session.verify = ssl_context
-            response = self._make_request(self._base_url_localized, {"check_logged_in": "1"}, session)
+            response = self._make_request(self._base_url_balance, {"check_logged_in": "1"}, session)
             return self._parse_balance_from_response(response)
 
     def get_transactions(


### PR DESCRIPTION
Fixes login redirect problem from https://users.pluxee.be/nl to https://users.pluxee.be/nl/user/login.

- Keep `_base_url_localized` for SSL
- Use `_base_url_login` for login
- Use `_base_url_balance` to get balance
- Keep `_base_url_transactions` to get transactions
- Fix logged in check in async client not working properly for async get transactions example